### PR TITLE
Fix delete problem from normalizeMetadata method failing as expects a…

### DIFF
--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -267,7 +267,7 @@ class CloudinaryAdapter implements AdapterInterface
 
     private function normalizeMetadata($resource)
     {
-        return !is_array($resource) ? false : [
+        return !$resource instanceof \ArrayObject && !is_array($resource) ? false : [
             'type' => 'file',
             'path' => $resource['public_id'],
             'size' => array_key_exists('bytes', $resource) ? $resource['bytes'] : false,


### PR DESCRIPTION
Fix delete problem from normalizeMetadata method failing as expects an array back from Cloudinary, but receives a custom response object.

Sorry I ran out of time to check the tests. Nothing should break though as the normalizeMetadata method still responds to an array as before, but also now responds to the ArrayObject.