### PR TITLE
fixed the double file extension after uploading to cloudinary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=5.4.0",
     "ext-fileinfo": "*",
     "league/flysystem": "~1.0",
-    "cloudinary/cloudinary_php": "~1.1"
+    "cloudinary/cloudinary_php": "^1.8.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.3.1",

--- a/src/ApiFacade.php
+++ b/src/ApiFacade.php
@@ -42,49 +42,49 @@ class ApiFacade extends BaseApi
     }
 
     /**
-     * @param string $path
+     * @param string $publicId
      * @param string $contents
      *
      * @return array
      */
-    public function upload($path, $contents)
+    public function upload($publicId, $contents)
     {
-        return Uploader::upload(new DataUri($contents), ['public_id' =>  pathinfo($path, PATHINFO_FILENAME)]);
+        return Uploader::upload(new DataUri($contents), ['public_id' => $publicId]);
     }
 
     /**
-     * @param string $path
-     * @param string $newpath
+     * @param string $publicId
+     * @param string $newPublicId
      *
      * @return array
      */
-    public function rename($path, $newpath)
+    public function rename($publicId, $newPublicId)
     {
-        return Uploader::rename($path, $newpath);
+        return Uploader::rename($publicId, $newPublicId);
     }
 
     /**
-     * Returns content of file with given path.
+     * Returns content of file with given public id.
      *
-     * @param string $path
+     * @param string $publicId
      *
      * @return resource
      */
-    public function content($path)
+    public function content($publicId)
     {
-        return fopen($this->url($path), 'r');
+        return fopen($this->url($publicId), 'r');
     }
 
     /**
-     * Returns URL of file with given $path and $transformations.
+     * Returns URL of file with given public id and transformations.
      *
-     * @param string $path
+     * @param string $publicId
      * @param array  $transformations
      *
      * @return string
      */
-    public function url($path, array $transformations = [])
+    public function url($publicId, array $transformations = [])
     {
-        return cloudinary_url($path, $transformations);
+        return cloudinary_url($publicId, $transformations);
     }
 }

--- a/src/ApiFacade.php
+++ b/src/ApiFacade.php
@@ -49,7 +49,7 @@ class ApiFacade extends BaseApi
      */
     public function upload($path, $contents)
     {
-        return Uploader::upload(new DataUri($contents), ['public_id' => $path]);
+        return Uploader::upload(new DataUri($contents), ['public_id' =>  pathinfo($path, PATHINFO_FILENAME)]);
     }
 
     /**

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -54,10 +54,8 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function update($path, $contents, Config $config)
     {
-        $publicId = $this->pathToPublicId($path);
-
         // Cloudinary does not distinguish create and update
-        return $this->write($publicId, $contents, $config);
+        return $this->write($path, $contents, $config);
     }
 
     /**

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -289,7 +289,7 @@ class CloudinaryAdapter implements AdapterInterface
     }
 
     /**
-     * Returns a public id based on the filename but (without the file extension).
+     * Returns a public id based on the filename (without the file extension).
      *
      * @param $path
      * @return string

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -34,8 +34,10 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function write($path, $contents, Config $config)
     {
+        $publicId = $this->pathToPublicId($path);
+
         try {
-            return $this->normalizeMetadata($this->api->upload($path, $contents));
+            return $this->normalizeMetadata($this->api->upload($publicId, $contents));
         } catch (\Exception $e) {
             return false;
         }
@@ -52,8 +54,10 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function update($path, $contents, Config $config)
     {
+        $publicId = $this->pathToPublicId($path);
+
         // Cloudinary does not distinguish create and update
-        return $this->write($path, $contents, $config);
+        return $this->write($publicId, $contents, $config);
     }
 
     /**
@@ -66,8 +70,11 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function rename($path, $newpath)
     {
+        $publicId = $this->pathToPublicId($path);
+        $newPublicId = $this->pathToPublicId($newpath);
+
         try {
-            return (bool) $this->api->rename($path, $newpath);
+            return (bool) $this->api->rename($publicId, $newPublicId);
         } catch (\Exception $e) {
             return false;
         }
@@ -82,8 +89,10 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function delete($path)
     {
+        $publicId = $this->pathToPublicId($path);
+
         try {
-            $response = $this->api->delete_resources([$path]);
+            $response = $this->api->delete_resources([$publicId]);
 
             return $response['deleted'][$path] === 'deleted';
         } catch (Api\Error $e) {
@@ -162,9 +171,11 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function readStream($path)
     {
+        $publicId = $this->pathToPublicId($path);
+
         try {
             return [
-                'stream' => $this->api->content($path),
+                'stream' => $this->api->content($publicId),
                 'path' => $path,
             ];
         } catch (\Exception $e) {
@@ -222,8 +233,10 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function getMetadata($path)
     {
+        $publicId = $this->pathToPublicId($path);
+
         try {
-            return $this->normalizeMetadata($this->api->resource($path));
+            return $this->normalizeMetadata($this->api->resource($publicId));
         } catch (\Exception $e) {
             return false;
         }
@@ -273,5 +286,15 @@ class CloudinaryAdapter implements AdapterInterface
             'size' => array_key_exists('bytes', $resource) ? $resource['bytes'] : false,
             'timestamp' => array_key_exists('created_at', $resource) ? strtotime($resource['created_at']) : false,
         ];
+    }
+
+    /**
+     * Returns a public id based on the filename but (without the file extension).
+     *
+     * @param $path
+     * @return string
+     */
+    private function pathToPublicId($path) {
+        return pathinfo($path, PATHINFO_FILENAME);
     }
 }


### PR DESCRIPTION
The current composer configuration always installs the latest `cloudinary/cloudinary_php`, which is 1.8.0 and is not fully compatible. E.g. the files will be stored with a double file extension.

- This problem was solved
- The direct usage of paths as public ids was replaced
- To prevent such future problems, the required version of `cloudinary/cloudinary_php` was changed to `^1.8.0`

Similar approach to https://github.com/enl/flysystem-cloudinary/pull/10