### PR TITLE
Feature/add versioned url plugin

### DIFF
--- a/src/ApiFacade.php
+++ b/src/ApiFacade.php
@@ -126,24 +126,26 @@ class ApiFacade extends BaseApi
      * Returns content of file with given public id.
      *
      * @param string $path
-     * @param array $transformations
+     * @param array $options
+     *
      * @return resource
      */
-    public function content($path, array $transformations = [])
+    public function content($path, array $options = [])
     {
-        return fopen($this->url($path, $transformations), 'r');
+        return fopen($this->url($path, $options), 'r');
     }
 
     /**
      * Returns URL of file with given public id and transformations.
      *
      * @param string $path
-     * @param array  $transformations
+     * @param array  $options
+     *
      * @return string
      */
-    public function url($path, array $transformations = [])
+    public function url($path, array $options = [])
     {
-        return cloudinary_url($this->converter->pathToId($path), $transformations);
+        return cloudinary_url($this->converter->pathToId($path), $options);
     }
 
     /**

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -303,6 +303,7 @@ class CloudinaryAdapter implements AdapterInterface
             'path' => $resource['path'],
             'size' => array_key_exists('bytes', $resource) ? $resource['bytes'] : false,
             'timestamp' => array_key_exists('created_at', $resource) ? strtotime($resource['created_at']) : false,
+            'version' => array_key_exists('version', $resource) ? $resource['version'] : 1,
         ];
     }
 }

--- a/src/Plugin/GetUrl.php
+++ b/src/Plugin/GetUrl.php
@@ -14,8 +14,8 @@ class GetUrl extends AbstractPlugin
         return 'getUrl';
     }
 
-    public function handle($path, $transformations = [])
+    public function handle($path, $options = [])
     {
-        return $this->apiFacade->url($path, $transformations);
+        return $this->apiFacade->url($path, $options);
     }
 }

--- a/src/Plugin/GetVersionedUrl.php
+++ b/src/Plugin/GetVersionedUrl.php
@@ -3,7 +3,11 @@
 
 namespace Enl\Flysystem\Cloudinary\Plugin;
 
-
+/**
+ * Class GetVersionedUrl
+ *
+ * @package Enl\Flysystem\Cloudinary\Plugin
+ */
 class GetVersionedUrl extends AbstractPlugin
 {
     const VERSION_OPTION = 'version';
@@ -21,6 +25,8 @@ class GetVersionedUrl extends AbstractPlugin
     /**
      * Returns url with version.
      * If no version was passed to $options, than the latest version will be used.
+     * Note that getting latest version is one more api call. Make sure you won't exceed
+     * api calls limit of your cloudinary plan.
      *
      * @param string $path
      * @param array $options

--- a/src/Plugin/GetVersionedUrl.php
+++ b/src/Plugin/GetVersionedUrl.php
@@ -1,0 +1,52 @@
+<?php
+
+
+namespace Enl\Flysystem\Cloudinary\Plugin;
+
+
+class GetVersionedUrl extends AbstractPlugin
+{
+    const VERSION_OPTION = 'version';
+
+    /**
+     * Get the method name.
+     *
+     * @return string
+     */
+    public function getMethod()
+    {
+        return 'getVersionedUrl';
+    }
+
+    /**
+     * Returns url with version.
+     * If no version was passed to $options, than the latest version will be used.
+     *
+     * @param string $path
+     * @param array $options
+     *
+     * @return string
+     */
+    public function handle($path, $options = [])
+    {
+        if (!array_key_exists(self::VERSION_OPTION, $options)) {
+            $options[self::VERSION_OPTION] = $this->getLatestVersion($path);
+        }
+
+        return $this->apiFacade->url($path, $options);
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return int|mixed
+     */
+    private function getLatestVersion($path)
+    {
+        $resource = $this->apiFacade->resource($path);
+
+        return array_key_exists(self::VERSION_OPTION, $resource)
+            ? $resource[self::VERSION_OPTION]
+            : 1;
+    }
+}

--- a/src/Plugin/GetVersionedUrl.php
+++ b/src/Plugin/GetVersionedUrl.php
@@ -1,13 +1,7 @@
 <?php
 
-
 namespace Enl\Flysystem\Cloudinary\Plugin;
 
-/**
- * Class GetVersionedUrl
- *
- * @package Enl\Flysystem\Cloudinary\Plugin
- */
 class GetVersionedUrl extends AbstractPlugin
 {
     const VERSION_OPTION = 'version';

--- a/tests/AdapterAction/GetMetadataTest.php
+++ b/tests/AdapterAction/GetMetadataTest.php
@@ -24,16 +24,18 @@ class GetMetadataTest extends ActionTestCase
         $public_id = $path = 'file';
         $bytes = 123123;
         $created_at = date('Y-m-d H:i:s');
+        $version = time();
 
         list ($cloudinary, $api) = $this->buildAdapter();
 
-        $api->resource('file')->willReturn(compact('public_id', 'path', 'bytes', 'created_at'));
+        $api->resource('file')->willReturn(compact('public_id', 'path', 'bytes', 'created_at', 'version'));
 
         $expected = [
             'type' => 'file',
             'path' => $public_id,
             'size' => $bytes,
-            'timestamp' => strtotime($created_at)
+            'timestamp' => strtotime($created_at),
+            'version' => $version,
         ];
         $actual = $cloudinary->$method($public_id);
 

--- a/tests/AdapterAction/ListContentsTest.php
+++ b/tests/AdapterAction/ListContentsTest.php
@@ -75,16 +75,18 @@ class ListContentsTest extends ActionTestCase
         $public_id = $path = 'test';
         $bytes = 123123;
         $created_at = date('Y-m-d H:i:s');
+        $version = time();
 
         $api->resources(Argument::any())->willReturn([
-            'resources' => [compact('public_id', 'path', 'bytes', 'created_at')]
+            'resources' => [compact('public_id', 'path', 'bytes', 'created_at', 'version')]
         ]);
 
         $expected = [
             'type' => 'file',
             'path' => $public_id,
             'size' => $bytes,
-            'timestamp' => strtotime($created_at)
+            'timestamp' => strtotime($created_at),
+            'version' => $version,
         ];
 
         $actual = $cloudinary->listContents()[0];

--- a/tests/Plugin/GetVersionedUrlTest.php
+++ b/tests/Plugin/GetVersionedUrlTest.php
@@ -1,0 +1,60 @@
+<?php
+
+
+namespace Enl\Flysystem\Cloudinary\Test\Plugin;
+
+
+use Enl\Flysystem\Cloudinary\CloudinaryAdapter;
+use Enl\Flysystem\Cloudinary\Plugin\GetVersionedUrl;
+use League\Flysystem\Filesystem;
+use PHPUnit\Framework\TestCase;
+
+class GetVersionedUrlTest extends TestCase
+{
+    public function testPassesVersionToUrl()
+    {
+        list ($filesystem, $facade) = $this->mockFacade();
+        $version = time();
+        $options = ['version' => $version];
+        $facade->url('test.jpg', $options)->willReturn("http://cloudinary.url/v{$version}/test");
+
+        $content = $filesystem->getVersionedUrl('test.jpg', $options);
+        $this->assertEquals("http://cloudinary.url/v{$version}/test", $content);
+    }
+
+    public function resourceResponseProvider()
+    {
+        return [
+            [['version' => $version = time()], $version],
+            [[], 1],
+        ];
+    }
+
+    /**
+     * @param $resourceResponse
+     * @param $version
+     *
+     * @dataProvider resourceResponseProvider
+     */
+    public function testVersionedUrlWithoutVersionOption($resourceResponse, $version)
+    {
+        list ($filesystem, $facade) = $this->mockFacade();
+
+        $facade->resource('test.jpg')->willReturn($resourceResponse);
+
+        $facade->url('test.jpg', ['version' => $version])->willReturn("http://cloudinary.url/v{$version}/test");
+
+        $content = $filesystem->getVersionedUrl('test.jpg');
+        $this->assertEquals("http://cloudinary.url/v{$version}/test", $content);
+    }
+
+    private function mockFacade()
+    {
+        $api = $this->prophesize('\Enl\Flysystem\Cloudinary\ApiFacade');
+
+        $filesystem = new Filesystem(new CloudinaryAdapter($api->reveal()), ['disable_asserts' => true]);
+        $filesystem->addPlugin(new GetVersionedUrl($api->reveal()));
+
+        return [$filesystem, $api];
+    }
+}

--- a/tests/Plugin/GetVersionedUrlTest.php
+++ b/tests/Plugin/GetVersionedUrlTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Enl\Flysystem\Cloudinary\Test\Plugin;
-
 
 use Enl\Flysystem\Cloudinary\CloudinaryAdapter;
 use Enl\Flysystem\Cloudinary\Plugin\GetVersionedUrl;


### PR DESCRIPTION
Добавила новый плагин `GetVersionedUrl`. Не стала в `GetUrl` это пихать, вдруг кому-то надо вообще без версии получать `url`. В общем, если передашь версию она и будет использоваться, если не передашь, то из клаудинари запроситься последняя и будет использована она. Я не нашла подтверждений тому, что `version` всегда обязательно приходит в ответ, так что сделала версию равной 1, если ее вдруг не будет в ответе (возможно стоит сделать `time()` по умолчанию).

И переименовала еще аргумент `transformation` в `options` в некоторых методах.