### PR TITLE
Добавлена возможность устанавливать опции для удаления

### DIFF
--- a/src/ApiFacade.php
+++ b/src/ApiFacade.php
@@ -18,6 +18,11 @@ class ApiFacade extends BaseApi
     private $converter;
 
     /**
+     * @var array
+     */
+    private $deletingOptions = [];
+
+    /**
      * @param array $options
      * @param PathConverterInterface|null $converter
      */
@@ -43,6 +48,15 @@ class ApiFacade extends BaseApi
     }
 
     /**
+     * Sets the options for resource deleting operation.
+     * @param array $options
+     */
+    public function setDeletingOptions(array $options)
+    {
+        $this->deletingOptions = $options;
+    }
+
+    /**
      * @param $path
      * @param array $options
      *
@@ -63,14 +77,21 @@ class ApiFacade extends BaseApi
         return $response;
     }
 
-    public function deleteResources($paths, $options = [])
+    /**
+     * @param array $paths
+     * @param array $options
+     *
+     * @return BaseApi\Response
+     */
+    public function deleteResources(array $paths, array $options = [])
     {
         $map = [];
 
         foreach ($paths as $path) {
             $map[$this->converter->pathToId($path)] = $path;
         }
-        $response = parent::delete_resources(array_keys($map), $options);
+
+        $response = parent::delete_resources(array_keys($map), array_merge($options, $this->deletingOptions));
 
         $deleted = [];
 

--- a/src/ApiFacade.php
+++ b/src/ApiFacade.php
@@ -20,7 +20,7 @@ class ApiFacade extends BaseApi
     /**
      * @var array
      */
-    private $deletingOptions = [];
+    private $deleteOptions = [];
 
     /**
      * @param array $options
@@ -51,9 +51,9 @@ class ApiFacade extends BaseApi
      * Sets the options for resource deleting operation.
      * @param array $options
      */
-    public function setDeletingOptions(array $options)
+    public function setDeleteOptions(array $options)
     {
-        $this->deletingOptions = $options;
+        $this->deleteOptions = $options;
     }
 
     /**
@@ -91,7 +91,7 @@ class ApiFacade extends BaseApi
             $map[$this->converter->pathToId($path)] = $path;
         }
 
-        $response = parent::delete_resources(array_keys($map), array_merge($options, $this->deletingOptions));
+        $response = parent::delete_resources(array_keys($map), array_merge($this->deleteOptions, $options));
 
         $deleted = [];
 

--- a/tests/ApiFacadeTest.php
+++ b/tests/ApiFacadeTest.php
@@ -57,4 +57,5 @@ class ApiFacadeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('preset', \Cloudinary::config_get('upload_preset'));
     }
+
 }

--- a/tests/ApiFacadeTest.php
+++ b/tests/ApiFacadeTest.php
@@ -57,5 +57,4 @@ class ApiFacadeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('preset', \Cloudinary::config_get('upload_preset'));
     }
-
 }


### PR DESCRIPTION
Из-за того, что `AdapterInterface` из пакета `flysystem` не позволяет передавать в метод `delete` опции, был добавлен метод `setDeletingOptions` в `ApiFacade`. Они будут применяться при каждом удалении, это может быть полезно например, когда необходимо инвалидировать кэш при удалении.

Возможно стоит об этом сказать где-нибудь в документации. 