### PR TITLE
Fix array_key_exists deprecation

### DIFF
--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -235,7 +235,7 @@ class CloudinaryAdapter implements AdapterInterface
         foreach ($response['resources'] as $resource) {
             $storage['files'][] = $this->normalizeMetadata($resource);
         }
-        if (array_key_exists('next_cursor', $response)) {
+        if (property_exists($response, 'next_cursor')) {
             $storage['next_cursor'] = $response['next_cursor'];
 
             return $this->doListContents($directory, $storage);

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -301,9 +301,9 @@ class CloudinaryAdapter implements AdapterInterface
         return !$resource instanceof \ArrayObject && !is_array($resource) ? false : [
             'type' => 'file',
             'path' => $resource['path'],
-            'size' => array_key_exists('bytes', $resource) ? $resource['bytes'] : false,
-            'timestamp' => array_key_exists('created_at', $resource) ? strtotime($resource['created_at']) : false,
-            'version' => array_key_exists('version', $resource) ? $resource['version'] : 1,
+            'size' => isset($resource['bytes']) ? $resource['bytes'] : false,
+            'timestamp' => isset($resource['created_at']) ? strtotime($resource['created_at']) : false,
+            'version' => isset($resource['version']) ? $resource['version'] : 1,
         ];
     }
 }

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -235,7 +235,7 @@ class CloudinaryAdapter implements AdapterInterface
         foreach ($response['resources'] as $resource) {
             $storage['files'][] = $this->normalizeMetadata($resource);
         }
-        if (property_exists($response, 'next_cursor')) {
+        if (isset($response['next_cursor'])) {
             $storage['next_cursor'] = $response['next_cursor'];
 
             return $this->doListContents($directory, $storage);


### PR DESCRIPTION
At this point, `$response` is an object, and the use of `array_key_exists` on objects is deprecated as of PHP 7.4

https://wiki.php.net/rfc/deprecations_php_7_4#array_key_exists_with_objects

~~Use property_exists instead, which is supported after PHP 5.1~~

~~https://www.php.net/manual/en/function.property-exists.php~~

Update: 
Seems there is a weird tension in the use of `\ArrayObject` where you can't use `array_key_exists ` because it is still an object, but it can have keys/values like one. Looking at a sample response, `next_cursor` is a key at the same level as `resources`, so it seems `isset` is the
only option.

Logically I think that still works because if the value of `$response['next_cursor']` is null, then this code should not execute.
