### PR TITLE
Destroying assets instead of deleting them

### DIFF
--- a/src/ApiFacade.php
+++ b/src/ApiFacade.php
@@ -78,27 +78,14 @@ class ApiFacade extends BaseApi
     }
 
     /**
-     * @param array $paths
+     * @param $path
      * @param array $options
      *
      * @return BaseApi\Response
      */
-    public function deleteResources(array $paths, array $options = [])
+    public function deleteResource($path, array $options = [])
     {
-        $map = [];
-
-        foreach ($paths as $path) {
-            $map[$this->converter->pathToId($path)] = $path;
-        }
-
-        $response = parent::delete_resources(array_keys($map), array_merge($this->deleteOptions, $options));
-
-        $deleted = [];
-
-        foreach ($response['deleted'] as $id => $status) {
-            $deleted[$map[$id]] = $status;
-        }
-        $response['deleted'] = $deleted;
+        $response = Uploader::destroy($this->converter->pathToId($path), array_merge($this->deleteOptions, $options));
 
         return $response;
     }

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -8,7 +8,6 @@ use League\Flysystem\Adapter\Polyfill\StreamedCopyTrait;
 use League\Flysystem\Adapter\Polyfill\StreamedTrait;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
-use League\Flysystem\Filesystem;
 
 class CloudinaryAdapter implements AdapterInterface
 {
@@ -89,10 +88,10 @@ class CloudinaryAdapter implements AdapterInterface
     public function delete($path)
     {
         try {
-            $response = $this->api->deleteResources([$path]);
+            $response = $this->api->deleteResource($path);
 
-            return $response['deleted'][$path] === 'deleted';
-        } catch (Api\Error $e) {
+            return $response['result'] === 'ok';
+        } catch (\Exception $e) {
             return false;
         }
     }


### PR DESCRIPTION
I favor this approach because it doesn't use the management api.

In our project we have to set `invalidate: true` in the delete options and this doesn't work with the management api, but works with `Uploader::destroy`.

Because there are no batch deletions, there should be no reason to use `delete_resources`.

Looking forward to feedback